### PR TITLE
Correct binary name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This package can be found on [Packagist](http://packagist.org) and installed wit
 
 The binaries will then be located at:
 
-    vendor/jshmrtn/wkhtmltopdf-linux-trusty-amd64/bin/wkhtmltopdf-linux-trusty-i386
-    vendor/jshmrtn/wkhtmltopdf-linux-trusty-amd64/bin/wkhtmltoimage-linux-trusty-i386
+    vendor/jshmrtn/wkhtmltopdf-linux-trusty-i386/bin/wkhtmltopdf-linux-trusty-i386
+    vendor/jshmrtn/wkhtmltopdf-linux-trusty-i386/bin/wkhtmltoimage-linux-trusty-i386
 
 Also a symlink will be created in your configured bin/ folder, for example:
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ In case this package does _not_ work on your system, try installing the matching
 
 This package can be found on [Packagist](http://packagist.org) and installed with [Composer](https://getcomposer.org/).
 
-    php composer.phar require jshmrtn/wkhtmltopdf-linux-trusty-amd64 "0.12.3"
+    php composer.phar require jshmrtn/wkhtmltopdf-linux-trusty-i386 "0.12.3"
 
 The binaries will then be located at:
 
-    vendor/jshmrtn/wkhtmltopdf-linux-trusty-amd64/bin/wkhtmltopdf-linux-trusty-amd64
-    vendor/jshmrtn/wkhtmltopdf-linux-trusty-amd64/bin/wkhtmltoimage-linux-trusty-amd64
+    vendor/jshmrtn/wkhtmltopdf-linux-trusty-amd64/bin/wkhtmltopdf-linux-trusty-i386
+    vendor/jshmrtn/wkhtmltopdf-linux-trusty-amd64/bin/wkhtmltoimage-linux-trusty-i386
 
 Also a symlink will be created in your configured bin/ folder, for example:
 
-    vendor/bin/wkhtmltopdf-linux-trusty-amd64
-    vendor/bin/wkhtmltoimage-linux-trusty-amd64
+    vendor/bin/wkhtmltopdf-linux-trusty-i386
+    vendor/bin/wkhtmltoimage-linux-trusty-i386


### PR DESCRIPTION
Change binary name from `wkhtmltopdf-linux-trusty-amd64` to `wkhtmltopdf-linux-trusty-i386`
